### PR TITLE
Allowing empty Project numbers in Android Variants

### DIFF
--- a/admin-ui/app/dialogs/create-variant.html
+++ b/admin-ui/app/dialogs/create-variant.html
@@ -120,7 +120,7 @@
           <label class="col-sm-3 control-label" for="gcmProjectNumber"></label>
           <div class="col-sm-7">
             Project Number<br>
-            <input type="text" placeholder="e.g. 42" id="gcmProjectNumber" class="form-control" ng-model="variant.projectNumber" ng-required="variant.type == 'android'">
+            <input type="text" placeholder="e.g. 42" id="gcmProjectNumber" class="form-control" ng-model="variant.projectNumber">
           </div>
         </div>
       </div>

--- a/admin-ui/app/snippets/register-device/android.java
+++ b/admin-ui/app/snippets/register-device/android.java
@@ -12,7 +12,7 @@ public class PushApplication extends Application {
 
     private final String VARIANT_ID       = "{{ variant.variantID }}";
     private final String SECRET           = "{{ variant.secret }}";
-    private final String GCM_SENDER_ID    = "{{ variant.projectNumber }}";
+    private final String GCM_SENDER_ID    = {{ variant.projectNumber ? '"' + variant.projectNumber + '";': '""; // getString(R.string.gcm_defaultSenderId)'}}
     private final String UNIFIED_PUSH_URL = "{{ contextPath }}";
 
     @Override

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/AndroidVariant.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/AndroidVariant.java
@@ -29,7 +29,7 @@ public class AndroidVariant extends Variant {
     @Size(min = 1, max = 255, message = "Google Cloud Messaging Key must be max. 255 chars long")
     private String googleKey;
 
-    @Size(min = 1, max = 255, message = "Project Number must be max. 255 chars long")
+    @Size(max = 255, message = "Project Number must be max. 255 chars long")
     private String projectNumber;
 
     /**


### PR DESCRIPTION
@matzew This will let us edit a GCM variant and set a project number to be empty.