### PR TITLE
Early exit criteria for CN check

### DIFF
--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/apns/ApnsUtil.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/apns/ApnsUtil.java
@@ -97,6 +97,9 @@ public final class ApnsUtil {
                     if (PUSH_SUBJECTS.contains(matcher.group(1))) {
                         try{
                             certificate.checkValidity();
+                            // We can break here because otherwise we coud end up checking the same certificate
+                            // multiple times
+                            break;
                         } catch (CertificateExpiredException | CertificateNotYetValidException e) {
                             LOGGER.error("Provided APNs .p12 file is expired or not yet valid");
                             return false;


### PR DESCRIPTION
Add an early exit criteria to prevent checking the same cert multiple times.

ping @ziccardi

I've had a look if it would be easier to use the bouncycastle libs but it turns out that we only have them in our server dependencies at the moment (not usable in this subproject) and also we would have to include a number of different bouncycastle deps.